### PR TITLE
Skip approval screen

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -44,6 +44,9 @@ connectors:
 
       nameAttr: cn
 
+oauth2:
+  skipApprovalScreen: true
+
 # Unfortunately the api is too complex to be used here
 # As a consequence we have to setup client as staticClient, which means we will need one Dex instance per client app
 staticClients:


### PR DESCRIPTION
## Problem

- When authenticating through Dex, after logging in, we are displayed a screen asking to approve the application.

![image](https://github.com/user-attachments/assets/1bedd8a3-5e4b-450b-ac34-5406428fd6d5)

## Solution

- Skip it, as it is not very useful, and may confuse the user

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
