### PR TITLE
Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 OpenID Connect Provider based on YunoHost LDAP server
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://dexidp.io)
-[![Version: 2.43.1~ynh1](https://img.shields.io/badge/Version-2.43.1~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/dex/)
+[![Version: 2.43.1~ynh2](https://img.shields.io/badge/Version-2.43.1~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/dex/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/dex"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@ It shall NOT be edited by hand.
 OpenID Connect Provider based on YunoHost LDAP server
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://dexidp.io)
-[![Version: 2.43.1~ynh1](https://img.shields.io/badge/Version-2.43.1~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/dex/)
+[![Version: 2.43.1~ynh1](https://img.shields.io/badge/Version-2.43.1~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/dex/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/dex"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>
 <a href="https://github.com/YunoHost-Apps/dex_ynh/issues"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_report_an_issue.svg"/></a>
 </div>
+
+
+## Screenshots
+![Screenshot of Dex](./doc/screenshots/Dex_screenshot.png)
 
 ## 📦 Developer info
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Dex"
 description.en = "OpenID Connect Provider based on YunoHost LDAP server"
 description.fr = "Connecteur OpenID basé sur le serveur LDAP YunoHost"
 
-version = "2.43.1~ynh1"
+version = "2.43.1~ynh2"
 
 maintainers = [ "Limezy" ]
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -10,7 +10,7 @@ _download_dex_from_docker() {
     debian=$(lsb_release --codename --short)
     if [[ $debian = "bullseye" ]]; then
         docker_version="$(ynh_app_upstream_version)-distroless"
-    else; then
+    else
         docker_version="$(ynh_app_upstream_version)-alpine"
     fi
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -10,7 +10,7 @@ _download_dex_from_docker() {
     debian=$(lsb_release --codename --short)
     if [[ $debian = "bullseye" ]]; then
         docker_version="$(ynh_app_upstream_version)-distroless"
-    elif [[ $debian = "bookworm" ]]; then
+    else; then
         docker_version="$(ynh_app_upstream_version)-alpine"
     fi
 


### PR DESCRIPTION
## Problem

- this PR #85 makes dex work with Trixie, but no new version has been released.
- Without a new version of this package, packages like [headscale](https://github.com/YunoHost-Apps/headscale_ynh) or [lasuite-docs](https://github.com/YunoHost-Apps/lasuite-docs_ynh) won't work on trixie.

## Solution

- Bump the version!

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
